### PR TITLE
Re-add the model.collection association for the models in the all collection after fetch

### DIFF
--- a/supermodel.js
+++ b/supermodel.js
@@ -483,6 +483,9 @@
       if (id && (model = all.get(id))) {
         model.parse(attrs);
         model.set(attrs);
+        if (!model.collection && options && options.collection) {
+          model.collection = options.collection;
+        }
         return model;
       }
 


### PR DESCRIPTION
On a collection reset, the collection association would be removed from the models in the `all` collection. Then if the fetched models matched those in the `all` collection we would pull the models from there rather than running through the default initialize. This was causing the collection association to never be reset on those models. 

So if model.collection already exists on the models in the `all` collection we don't reset it otherwise we set it to `options.collection` if that exists.

My use case for this is I load a list of items, the user can then apply filters to that list which calls `collection.fetch({reset: true})`, the models returned will match models stored in the `all` collection but their collection associations have been removed by the collection reset.
