### PR TITLE
Modified model's static all() method to use the create() method.

### DIFF
--- a/supermodel.js
+++ b/supermodel.js
@@ -510,7 +510,16 @@
 
     // Return a collection of all models for a particular constructor.
     all: function() {
-      return this._all || (this._all = new Backbone.Collection);
+      if(!this._all){
+        var Constructor = this,
+          All = this.Collection || (Collection.extend({
+            model:function(attrs, options) {
+              return Constructor.create(attrs, options);
+            }
+        }));
+        this._all = new All();
+      }
+      return this._all;
     },
 
     // Return a hash of all associations for a particular constructor.


### PR DESCRIPTION
In instances where we want to inject models into a page from the server, it makes sense to use Model.all().add([...]), but the model instances were not being registered because they were using the default Backbone.Collection. 

I have modified it to use a pre-attached Model.Collection class (allowing extra customization/configuration), or automatically extending the Backbone.Collection's model() method to use Model.create().
