### PR TITLE
Fix Supermodel assignmend to global Context

### DIFF
--- a/supermodel.js
+++ b/supermodel.js
@@ -12,7 +12,7 @@
 
   // Globals
   else {
-    callback({}, root.Backbone, root._);
+    callback(root.Supermodel = {}, root.Backbone, root._);
   }
 
 }(this, function (Supermodel, Backbone, _) {


### PR DESCRIPTION
If used without AMD or CommonJS, the global context does currently not receive a Supermodel attribute, which makes it unusable.
