### PR TITLE
toJSON include related models.

### DIFF
--- a/supermodel.js
+++ b/supermodel.js
@@ -452,6 +452,17 @@
     toJSON: function() {
       var o = Backbone.Model.prototype.toJSON.apply(this, arguments);
       delete o[this.cidAttribute];
+      // if options set to include related models, set related model's toJSON response to
+      // the attribute of object the same value
+      if(this.withJSON) {
+        for (var i = 0; i < this.withJSON.length; i++) {
+          var related = this.withJSON[i];
+          // validate type of relationship exits and this model has an existing relationship
+          if (this[ related ] && this[ related ]() ) {
+            o[ related ] = this[ related ]().toJSON();
+          }
+        }
+      }
       return o;
     },
 


### PR DESCRIPTION
Template frameworks like Handlebars use the results of the `toJSON` for the data that is available to them to use. I've found it convenient to include related models in the `toJSON` response almost similar to the Eager Loading idea ORMs have. This is helpful when rendering say a post, and want to include the author or react based on the type of author for instance.

In the model we just set `withJSON` with the models to be included:

    var Post = Supermodel.Model.extend({
        urlRoot:App.apiURL+'posts',
        withJSON: ['user', 'image']
    });

The toJSON function will both test if the relationship type exists, and if this model has one related. If one exists- its toJSON is called and the result is assigned to the name of the relationship.

Their might be a better option name than withJSON. Feel free to test, I thought this might be nice.